### PR TITLE
feat: add support for SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=power-combinator] Move to circuit-input subgroup if SchallCircuitGroup is installed.
+    - [item=power-combinator-MK2] Move to circuit-input subgroup if SchallCircuitGroup is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-updates.schall-circuit-group")

--- a/data-updates/schall-circuit-group.lua
+++ b/data-updates/schall-circuit-group.lua
@@ -1,0 +1,4 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["power-combinator"].subgroup = "circuit-input"
+  data.raw.item["power-combinator-MK2"].subgroup = "circuit-input"
+end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.0",
-    "energy-combinator >= 1.1.1"
+    "energy-combinator >= 1.1.1",
+    "? SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
- [item=power-combinator] Move to circuit-input subgroup if SchallCircuitGroup is installed.
- [item=power-combinator-MK2] Move to circuit-input subgroup if SchallCircuitGroup is installed.